### PR TITLE
Fix undefined highlight fallback in vim textprop backend

### DIFF
--- a/autoload/lsp_cxx_hl/textprop.vim
+++ b/autoload/lsp_cxx_hl/textprop.vim
@@ -3,12 +3,15 @@
 let s:has_reltime = has('reltime')
 
 function! lsp_cxx_hl#textprop#syn_prop_type_add(name, resolved_hl_group) abort
-    call prop_type_add(a:name, {
-                \ 'highlight': a:resolved_hl_group,
+    let l:opts = {
                 \ 'start_incl': 1,
                 \ 'end_incl': 0,
                 \ 'priority': g:lsp_cxx_hl_syntax_priority
-                \ })
+                \ }
+    if !empty(a:resolved_hl_group)
+       let l:opts['highlight'] = a:resolved_hl_group
+     endif
+    call prop_type_add(a:name, l:opts)
 endfunction
 
 function! lsp_cxx_hl#textprop#gen_prop_id() abort

--- a/autoload/lsp_cxx_hl/textprop.vim
+++ b/autoload/lsp_cxx_hl/textprop.vim
@@ -10,7 +10,7 @@ function! lsp_cxx_hl#textprop#syn_prop_type_add(name, resolved_hl_group) abort
                 \ }
     if !empty(a:resolved_hl_group)
        let l:opts['highlight'] = a:resolved_hl_group
-     endif
+    endif
     call prop_type_add(a:name, l:opts)
 endfunction
 

--- a/autoload/lsp_cxx_hl/textprop/symbols.vim
+++ b/autoload/lsp_cxx_hl/textprop/symbols.vim
@@ -114,10 +114,6 @@ function! s:hl_symbols(bufnr, timer) abort
                         \ l:sym['kind'],
                         \ l:sym['storage'])
 
-            if len(l:resolved_hl_group) == 0
-                let l:resolved_hl_group = 'None'
-            endif
-
             call lsp_cxx_hl#textprop#syn_prop_type_add(l:hl_group,
                         \ l:resolved_hl_group)
 
@@ -146,7 +142,7 @@ function! s:hl_symbols(bufnr, timer) abort
             let l:byte_offset_warn_done = 1
         endif
 
-        if l:prop_type['highlight'] ==# 'None'
+        if !has_key(l:prop_type, 'highlight')
             if !has_key(l:missing_groups, l:hl_group)
                 let l:missing_groups[l:hl_group] = []
             endif


### PR DESCRIPTION
None/NONE are not actually builtin highlight groups, but rather reserved
names that act like them sometimes.
So prop_type_add('foo', {'highlight': 'None'}) is an error. Omitting the 'highlight'
key is fine, though.

Tested with coc.nvim + coc-clangd + clangd 11 + vim 8.1.2269