### PR TITLE
Remove custom highlight groups

### DIFF
--- a/doc/vim-lsp-cxx-highlight.txt
+++ b/doc/vim-lsp-cxx-highlight.txt
@@ -198,18 +198,6 @@ Default = 0.
   let g:lsp_cxx_hl_use_text_props = 1 
 <
 
--------------------------------------------------------------------------------
-
-                    *lsp_cxx_hl_light_bg* *g:lsp_cxx_hl_light_bg*
-g:lsp_cxx_hl_light_bg 
-
-Use default colors that are suitable for a light background color.
-
-Default = 0.
->
-  let g:lsp_cxx_hl_light_bg = 1 
-<
-
 ===============================================================================
 
                                        *vim-lsp-cxx-highlight-highlight-groups*

--- a/plugin/vim-lsp-cxx-highlight.vim
+++ b/plugin/vim-lsp-cxx-highlight.vim
@@ -22,7 +22,6 @@ let g:lsp_cxx_hl_use_nvim_text_props = get(g:,
             \ 'lsp_cxx_hl_use_nvim_text_props', has('nvim-0.3.0'))
 let g:lsp_cxx_hl_text_prop_refresh_count = get(g:,
             \ 'lsp_cxx_hl_text_prop_refresh_count', 10)
-let g:lsp_cxx_hl_light_bg = get(g:, 'lsp_cxx_hl_light_bg', 0)
 
 function s:initialize() abort
     let l:ok = 0

--- a/syntax/lsp_cxx_highlight.vim
+++ b/syntax/lsp_cxx_highlight.vim
@@ -21,17 +21,9 @@ hi default link LspCxxHlSkippedRegionBeginEnd Normal
 
 
 " Syntax Highlighting:
-"
-" Custom Highlight Groups
-if g:lsp_cxx_hl_light_bg
-    hi default LspCxxHlGroupEnumConstant ctermfg=Magenta guifg=#573F54 cterm=none gui=none
-    hi default LspCxxHlGroupNamespace ctermfg=Yellow guifg=#3D3D00 cterm=none gui=none
-    hi default LspCxxHlGroupMemberVariable ctermfg=Black guifg=Black
-else
-    hi default LspCxxHlGroupEnumConstant ctermfg=Magenta guifg=#AD7FA8 cterm=none gui=none
-    hi default LspCxxHlGroupNamespace ctermfg=Yellow guifg=#BBBB00 cterm=none gui=none
-    hi default LspCxxHlGroupMemberVariable ctermfg=White guifg=White
-endif
+hi default link LspCxxHlGroupEnumConstant Constant
+hi default link LspCxxHlGroupNamespace Type
+hi default link LspCxxHlGroupMemberVariable Identifier
 
 hi default link LspCxxHlSymUnknown Normal
 


### PR DESCRIPTION
Setting custom highlight groups makes them look not consistent with the user's color scheme.

- MemberVariable set to Identifier, while Variable and Parameter remain
  Normal